### PR TITLE
Problem: hydrad has to announce itself on LAN

### DIFF
--- a/hydrad.cfg
+++ b/hydrad.cfg
@@ -7,6 +7,6 @@ server
     
 #   Apply to the zpipes server only
 hydra_server
-    echo = binding Hydra service to 'tcp://*:31415'
+    echo = binding Hydra service to 'ipc://@/hydra' for local clients
     bind
-        endpoint = tcp://*:31415
+        endpoint = ipc://@/hydra


### PR DESCRIPTION
Solution: use UDP beaconing (via CZMQ zbeacon class)
- broadcast UDP frame on port 5670 once per second
- frame contains 8 bytes: [H][Y][D][R][A][0x01][port] where the port
  is two-byte value in network order.

Recipient gets hydrad network address via UDP recvfrom, and uses port
to know where to make its TCP connection via ZeroMQ.

Note: UDP beaconing and TCP protocol should eventualy be written up
as an RFC along similar lines as ZRE RFC 36.
