### PR TITLE
Problem: current version of zproto defines global zmq-context for sockets

### DIFF
--- a/main/clojure/src/org/zproto/hydra_msg.clj
+++ b/main/clojure/src/org/zproto/hydra_msg.clj
@@ -99,23 +99,19 @@
   (failed [this routing-id reason]
     (HydraMsg/sendFailed socket routing-id reason)))
 
-(defn client-socket
-  ([endpoint context]
-    (let [socket (doto (zmq/socket context :dealer)
-                   (zmq/set-receive-timeout 1000)
-                   (zmq/connect endpoint))]
-      (->HydraMsgSocket socket)))
-  ([endpoint]
-    (client-socket endpoint (zmq/context))))
+(def context (zmq/context))
 
-(defn server-socket
-  ([endpoint context]
-    (let [socket (doto (zmq/socket context :router)
-                   (zmq/set-receive-timeout 1000)
-                   (zmq/bind endpoint))]
-       (->HydraMsgSocket socket)))
-  ([endpoint]
-    (server-socket endpoint (zmq/context))))
+(defn client-socket [endpoint]
+  (let [socket (doto (zmq/socket context :dealer)
+                 (zmq/set-receive-timeout 1000)
+                 (zmq/connect endpoint))]
+    (->HydraMsgSocket socket)))
+
+(defn server-socket [endpoint]
+  (let [socket (doto (zmq/socket context :router)
+                 (zmq/set-receive-timeout 1000)
+                 (zmq/bind endpoint))]
+     (->HydraMsgSocket socket)))
 
 (defn recv [{:keys [socket]}]
   (HydraMsg/recv socket))

--- a/main/clojure/test/org/zproto/hydra_server_test.clj
+++ b/main/clojure/test/org/zproto/hydra_server_test.clj
@@ -1,8 +1,7 @@
 (ns org.zproto.hydra-server-test
   (:require [clojure.test :refer :all]
             [org.zproto.hydra-server :as server]
-            [org.zproto.hydra-msg :as msg]
-            [zeromq.zmq :as zmq])
+            [org.zproto.hydra-msg :as msg])
   (:import [org.zproto HydraMsg]))
 
 (def test-endpoint "inproc://hydra-server-test")
@@ -21,9 +20,8 @@
         "dummy-post-id-2"))))
 
 (defn setup [& [connect?]]
-  (let [context (zmq/context)
-        srv-sock (msg/server-socket test-endpoint context)
-        cl-sock (msg/client-socket test-endpoint context)
+  (let [srv-sock (msg/server-socket test-endpoint)
+        cl-sock (msg/client-socket test-endpoint)
         srv (server/->Server srv-sock (atom {}) dummy-backend)]
     (when connect?
       (msg/hello cl-sock)
@@ -148,11 +146,10 @@
 
 
 (deftest multiple-clients
-  (let [context (zmq/context)
-        srv-sock (msg/server-socket test-endpoint context)
+  (let [srv-sock (msg/server-socket test-endpoint)
         srv (server/->Server srv-sock (atom {}) dummy-backend)
-        client-1 (msg/client-socket test-endpoint context)
-        client-2 (msg/client-socket test-endpoint context)]
+        client-1 (msg/client-socket test-endpoint)
+        client-2 (msg/client-socket test-endpoint)]
     (try
       (let [r1 (server-client-comm client-1 srv srv-sock msg/goodbye)
             r2 (server-client-comm client-2 srv srv-sock msg/get-tags)]


### PR DESCRIPTION
Solution: remove usage of explicit contexts in test.
