### PR TITLE
Problem: current clojure server reverses the state/event model  hierarchy

### DIFF
--- a/main/clojure/src/org/zproto/hydra_server.clj
+++ b/main/clojure/src/org/zproto/hydra_server.clj
@@ -6,12 +6,12 @@
 (alter-var-root #'*out* (constantly *out*))
 
 (defprotocol HydraServer
-  (hello    [this routing-id])
-  (get-tags [this routing-id])
-  (get-tag  [this routing-id tag])
-  (get-post [this routing-id post-id])
-  (goodbye  [this routing-id])
-  (invalid  [this routing-id]))
+  (hello    [this routing-id msg])
+  (get-tags [this routing-id msg])
+  (get-tag  [this routing-id msg])
+  (get-post [this routing-id msg])
+  (goodbye  [this routing-id msg])
+  (invalid  [this routing-id msg]))
 
 (defprotocol HydraServerBackend
   (get-latest-post [this])
@@ -38,60 +38,56 @@
 
 (defrecord Server [socket state backend]
   HydraServer
-  (hello [this routing-id]
-    (case (get @state routing-id)
-      :start (let [post-id (get-latest-post backend)]
-               (msg/hello-ok socket routing-id post-id)
-               (next-state state routing-id :start :connected))
+  (hello [this routing-id msg]
+    (let [post-id (get-latest-post backend)]
+      (msg/hello-ok socket routing-id post-id)
+      (next-state state routing-id :start :connected)))
 
-      (invalid this routing-id)))
+  (get-tags [this routing-id msg]
+    (let [tags (get-all-tags backend)]
+      (msg/get-tags-ok socket routing-id tags)))
 
-  (get-tags [this routing-id]
-    (case (get @state routing-id)
-      :connected (let [tags (get-all-tags backend)]
-                   (msg/get-tags-ok socket routing-id tags))
+  (get-tag [this routing-id msg]
+    (if-let [post-id (get-single-tag backend (.tag ^HydraMsg msg))]
+      (msg/get-tag-ok socket routing-id (.tag ^HydraMsg msg) post-id)
+      (msg/failed socket routing-id (format "no post for tag %s" (.tag ^HydraMsg msg)))))
 
-      (invalid this routing-id)))
+  (get-post [this routing-id msg]
+    (if-let [post-data (get-single-post backend (.post_id ^HydraMsg msg))]
+      (apply msg/get-post-ok socket routing-id post-data)
+      (msg/failed socket
+                  routing-id
+                  (format "post not found: %s" (.post_id ^HydraMsg msg)))))
 
-  (get-tag [this routing-id tag]
-    (case (get @state routing-id)
-      :connected (if-let [post-id (get-single-tag backend tag)]
-                   (msg/get-tag-ok socket routing-id tag post-id)
-                   (msg/failed socket routing-id (format "no post for tag %s" tag)))
-      (invalid this routing-id)))
-
-  (get-post [this routing-id post-id]
-    (case (get @state routing-id)
-      :connected (if-let [post-data (get-single-post backend post-id)]
-                   (apply msg/get-post-ok socket routing-id post-data)
-                   (msg/failed socket
-                               routing-id
-                               (format "post not found: %s" post-id)))
-
-      (invalid this routing-id)))
-
-  (invalid [this routing-id]
+  (invalid [this routing-id msg]
     (msg/invalid socket routing-id))
 
-  (goodbye [this routing-id]
-    (case (get @state routing-id)
-      :connected  (msg/goodbye-ok socket routing-id)
-      (invalid this routing-id))))
+  (goodbye [this routing-id msg]
+    (msg/goodbye-ok socket routing-id)))
 
+
+(def state-events
+  {:start {HydraMsg/HELLO hello
+           :*       invalid}
+   :connected {HydraMsg/GET_TAGS get-tags
+               HydraMsg/GET_TAG  get-tag
+               HydraMsg/GET_POST get-post
+               HydraMsg/GOODBYE  goodbye
+               :* invalid}})
+
+(def select-handler
+  (memoize
+   (fn [state event-id]
+     (or (get-in state-events [state event-id])
+         (get-in state-events [state :*])))))
 
 (defn match-msg
   [{:keys [state] :as server} ^HydraMsg msg]
   (let [id (.id msg)
-        routing-id (.routingId msg)]
-    (swap! state maybe-setup-session routing-id)
-    (cond
-     (= id HydraMsg/HELLO)    (hello    server routing-id)
-     (= id HydraMsg/GET_TAGS) (get-tags server routing-id)
-     (= id HydraMsg/GET_TAG)  (get-tag  server routing-id (.tag msg))
-     (= id HydraMsg/GET_POST) (get-post server routing-id (.post_id msg))
-     (= id HydraMsg/GOODBYE)  (goodbye  server routing-id)
-
-     :default                 (invalid  server routing-id))))
+        routing-id (.routingId msg)
+        initialized-state (swap! state maybe-setup-session routing-id)]
+    (let [handler (select-handler (get initialized-state routing-id) id)]
+      (handler server routing-id msg))))
 
 (defn server-loop
   [socket backend]


### PR DESCRIPTION
Solution: match state first, then event type. This corresponds more closely with the way the model is represented in xml and should make code generation more straightforward.
